### PR TITLE
Latest msg confirm only

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12703,6 +12703,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-loader-spinner": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react-loader-spinner/-/react-loader-spinner-4.0.0.tgz",
+      "integrity": "sha512-RU2vpEej6G4ECei0h3q6bgLU10of9Lw5O+4AwF/mtkrX5oY20Sh/AxoPJ7etbrs/7Q3u4jN5qwCwGLRKCHpk6g==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-redux": {
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "moment": "^2.29.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react-loader-spinner": "^4.0.0",
     "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.0",

--- a/client/src/components/ActiveChat/ActiveChat.js
+++ b/client/src/components/ActiveChat/ActiveChat.js
@@ -5,14 +5,15 @@ import { Box } from '@material-ui/core';
 
 // local
 import { messagesRead } from '../../store/utils/thunkCreators';
-import { Input, Header, Messages } from './index';
+import { Input, Header, Messages, OtherUserBubble } from './index';
 
 const useStyles = makeStyles(theme => ({
   root: {
     display: 'flex',
     flexDirection: 'column',
     maxHeight: '100vh',
-    overflow: 'auto',
+    overflowY: 'auto',
+    overflowX: 'hidden',
     [theme.breakpoints.up('md')]: {
       minHeight: '100vh',
     },
@@ -27,7 +28,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const ActiveChat = ({ user, conversation = {} }) => {
+const ActiveChat = ({ user, conversation = {}, documentVisible }) => {
   const classes = useStyles();
   const messagesLengthRef = useRef(conversation.messages?.length || 0);
   const messageInput = useRef(null);
@@ -47,10 +48,10 @@ const ActiveChat = ({ user, conversation = {} }) => {
   // mark messages read when active chat is showing a conversation
   // with unread messages.
   useEffect(() => {
-    if (conversation.unreadMessages?.length > 0) {
+    if (conversation.unreadMessages?.length > 0 && documentVisible) {
       dispatch(messagesRead(conversation, user.id));
     }
-  }, [conversation, dispatch, user.id]);
+  }, [conversation, dispatch, user.id, documentVisible]);
 
   return (
     <Box className={classes.root}>
@@ -61,11 +62,22 @@ const ActiveChat = ({ user, conversation = {} }) => {
             online={conversation.otherUser.online || false}
           />
           <Box className={classes.chatContainer}>
-            <Messages
-              messages={conversation.messages}
-              otherUser={conversation.otherUser}
-              userId={user.id}
-            />
+            <Box>
+              <Messages
+                messages={conversation.messages}
+                otherUser={conversation.otherUser}
+                userId={user.id}
+              />
+              {/* Show other user typing indicator when other user is typing */}
+              {conversation.senderTyping && (
+                <OtherUserBubble
+                  text={null}
+                  time={'Now'}
+                  otherUser={conversation.otherUser}
+                />
+              )}
+            </Box>
+            {/* End other user typing indicator. */}
             <Input
               otherUser={conversation.otherUser}
               conversationId={conversation.id}

--- a/client/src/components/ActiveChat/ActiveChat.js
+++ b/client/src/components/ActiveChat/ActiveChat.js
@@ -7,13 +7,15 @@ import { Box } from '@material-ui/core';
 import { messagesRead } from '../../store/utils/thunkCreators';
 import { Input, Header, Messages } from './index';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(theme => ({
   root: {
     display: 'flex',
-    flexGrow: 8,
     flexDirection: 'column',
-    height: '100vh',
+    maxHeight: '100vh',
     overflow: 'auto',
+    [theme.breakpoints.up('md')]: {
+      minHeight: '100vh',
+    },
   },
   chatContainer: {
     marginLeft: 41,

--- a/client/src/components/ActiveChat/Input.js
+++ b/client/src/components/ActiveChat/Input.js
@@ -2,12 +2,15 @@ import React, { useState } from 'react';
 import { FormControl, FilledInput } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { connect } from 'react-redux';
+
+// local
 import { postMessage } from '../../store/utils/thunkCreators';
+import socket from '../../socket';
 
 const styles = {
   root: {
     justifySelf: 'flex-end',
-    marginTop: 20,
+    marginTop: 35,
   },
   input: {
     height: 70,
@@ -29,14 +32,17 @@ const Input = ({
 
   const handleChange = event => {
     setText(event.target.value);
+    socket.emit('sender-typing', { conversationId, otherUserId: otherUser.id });
   };
 
   const handleSubmit = async event => {
     event.preventDefault();
+    const text = event.target.text.value;
+    if (!text) return;
     // add sender user info if posting to a brand new convo,
     // so that the other user will have access to username, profile pic, etc.
     const reqBody = {
-      text: event.target.text.value,
+      text,
       recipientId: otherUser.id,
       conversationId: conversationId,
       sender: conversationId ? null : user,

--- a/client/src/components/ActiveChat/Input.js
+++ b/client/src/components/ActiveChat/Input.js
@@ -7,7 +7,7 @@ import { postMessage } from '../../store/utils/thunkCreators';
 const styles = {
   root: {
     justifySelf: 'flex-end',
-    marginTop: 15,
+    marginTop: 20,
   },
   input: {
     height: 70,

--- a/client/src/components/ActiveChat/Messages.js
+++ b/client/src/components/ActiveChat/Messages.js
@@ -1,9 +1,14 @@
-import React from 'react';
+import { memo } from 'react';
 import { Avatar, Box, makeStyles } from '@material-ui/core';
 import { SenderBubble, OtherUserBubble } from '../ActiveChat';
 import moment from 'moment';
 
 const useStyles = makeStyles(() => ({
+  root: {
+    fontSize: '1.5rem',
+    letterSpacing: -0.2,
+    fontWeight: 'bold',
+  },
   confirmationBox: {
     position: 'absolute',
     width: '100%',
@@ -19,6 +24,7 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+/** Find the index of the last message user sent for showing the message read indicator. */
 const indexOfLastOwnMessage = (messages, userId) => {
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i].senderId === userId) return i;
@@ -31,7 +37,7 @@ const Messages = ({ messages, otherUser, userId }) => {
   const idxLastOwnMessage = indexOfLastOwnMessage(messages, userId);
 
   return (
-    <Box>
+    <Box className={classes.root}>
       {messages.map((message, idx) => {
         const time = moment(message.createdAt).format('h:mm');
         const latestOwnMessage = idx === idxLastOwnMessage;
@@ -62,4 +68,4 @@ const Messages = ({ messages, otherUser, userId }) => {
   );
 };
 
-export default Messages;
+export default memo(Messages);

--- a/client/src/components/ActiveChat/Messages.js
+++ b/client/src/components/ActiveChat/Messages.js
@@ -4,11 +4,14 @@ import { SenderBubble, OtherUserBubble } from '../ActiveChat';
 import moment from 'moment';
 
 const useStyles = makeStyles(() => ({
-  confimationBox: {
+  confirmationBox: {
+    position: 'absolute',
+    width: '100%',
+    bottom: -35,
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'flex-end',
-    margin: '10px 0px',
+    margin: '0px 0px 10px 0px',
   },
   avatar: {
     height: 20,
@@ -16,19 +19,28 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
+const indexOfLastOwnMessage = (messages, userId) => {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].senderId === userId) return i;
+  }
+  return -1;
+};
+
 const Messages = ({ messages, otherUser, userId }) => {
   const classes = useStyles();
+  const idxLastOwnMessage = indexOfLastOwnMessage(messages, userId);
 
   return (
     <Box>
-      {messages.map(message => {
+      {messages.map((message, idx) => {
         const time = moment(message.createdAt).format('h:mm');
+        const latestOwnMessage = idx === idxLastOwnMessage;
 
         return message.senderId === userId ? (
-          <div key={message.id}>
+          <div key={message.id} style={{ position: 'relative' }}>
             <SenderBubble text={message.text} time={time} />
-            {message.messageRead && (
-              <Box className={classes.confimationBox}>
+            {latestOwnMessage && message.messageRead && (
+              <Box className={classes.confirmationBox}>
                 <Avatar
                   alt="message read"
                   className={classes.avatar}

--- a/client/src/components/ActiveChat/OtherUserBubble.js
+++ b/client/src/components/ActiveChat/OtherUserBubble.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { Box, Typography, Avatar } from '@material-ui/core';
+import Loader from 'react-loader-spinner';
+import 'react-loader-spinner/dist/loader/css/react-spinner-loader.css';
 
 const useStyles = makeStyles(() => ({
   root: {
     display: 'flex',
-    margin: '10px 0px',
+    marginTop: '20px',
   },
   avatar: {
     height: 30,
@@ -14,21 +16,18 @@ const useStyles = makeStyles(() => ({
     marginTop: 6,
   },
   usernameDate: {
-    fontSize: 11,
     color: '#BECCE2',
-    fontWeight: 'bold',
-    marginBottom: 5,
   },
   bubble: {
     backgroundImage: 'linear-gradient(225deg, #6CC1FF 0%, #3A8DFF 100%)',
     borderRadius: '0 10px 10px 10px',
   },
   text: {
-    fontSize: 14,
-    fontWeight: 'bold',
     color: '#FFFFFF',
-    letterSpacing: -0.2,
     padding: 8,
+  },
+  loader: {
+    transform: 'translateY(1px)',
   },
 }));
 
@@ -47,7 +46,19 @@ const OtherUserBubble = ({ text, time, otherUser }) => {
           {otherUser.username} {time}
         </Typography>
         <Box className={classes.bubble}>
-          <Typography className={classes.text}>{text}</Typography>
+          {text ? (
+            <Typography className={classes.text}>{text}</Typography>
+          ) : (
+            <Box pt={1} pb={1}>
+              <Loader
+                type="ThreeDots"
+                color="#ffffffad"
+                height={10}
+                width={100}
+                className={classes.loader}
+              />
+            </Box>
+          )}
         </Box>
       </Box>
     </Box>

--- a/client/src/components/ActiveChat/SenderBubble.js
+++ b/client/src/components/ActiveChat/SenderBubble.js
@@ -7,7 +7,7 @@ const useStyles = makeStyles(() => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'flex-end',
-    margin: '10px 0px',
+    marginTop: '20px',
   },
   date: {
     fontSize: 11,
@@ -16,11 +16,8 @@ const useStyles = makeStyles(() => ({
     marginBottom: 5,
   },
   text: {
-    fontSize: 14,
     color: '#91A3C0',
-    letterSpacing: -0.2,
     padding: 8,
-    fontWeight: 'bold',
   },
   bubble: {
     background: '#F4F6FA',

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import { Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
@@ -14,9 +14,25 @@ const styles = {
 };
 
 const Home = ({ fetchConversations, classes, user }) => {
+  const [documentVisible, setDocumentVisible] = useState(true);
+
+  const setDocumentVisibleHandler = () => {
+    setDocumentVisible(document.visibilityState === 'visible');
+  };
+
   useEffect(() => {
     fetchConversations();
   }, [fetchConversations]);
+
+  useEffect(() => {
+    document.addEventListener('visibilitychange', setDocumentVisibleHandler);
+    return () => {
+      document.removeEventListener(
+        'visibilitychange',
+        setDocumentVisibleHandler
+      );
+    };
+  }, []);
 
   if (!user.id) {
     return <Redirect to="/login" />;
@@ -24,11 +40,11 @@ const Home = ({ fetchConversations, classes, user }) => {
   return (
     <Grid container component="main" className={classes.root}>
       <CssBaseline />
-      <Grid item xs={12} md={4}>
+      <Grid item xs={12} sm={4}>
         <SidebarContainer />
       </Grid>
-      <Grid item xs={12} md={8}>
-        <ActiveChat />
+      <Grid item xs={12} sm={8}>
+        <ActiveChat documentVisible={documentVisible} />
       </Grid>
     </Grid>
   );

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -24,8 +24,12 @@ const Home = ({ fetchConversations, classes, user }) => {
   return (
     <Grid container component="main" className={classes.root}>
       <CssBaseline />
-      <SidebarContainer />
-      <ActiveChat />
+      <Grid item xs={12} md={4}>
+        <SidebarContainer />
+      </Grid>
+      <Grid item xs={12} md={8}>
+        <ActiveChat />
+      </Grid>
     </Grid>
   );
 };

--- a/client/src/components/Sidebar/ChatContent.js
+++ b/client/src/components/Sidebar/ChatContent.js
@@ -37,6 +37,10 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+const messageSummary = message => {
+  return message?.length > 60 ? `${message.slice(0, 60)}...` : message;
+};
+
 const ChatContent = ({ conversation }) => {
   const classes = useStyles();
 
@@ -49,7 +53,7 @@ const ChatContent = ({ conversation }) => {
           {otherUser.username}
         </Typography>
         <Typography className={classes.previewText}>
-          {latestMessageText}
+          {messageSummary(latestMessageText)}
         </Typography>
       </Box>
       {conversation.unreadMessages?.length > 0 && (

--- a/client/src/components/Sidebar/Sidebar.js
+++ b/client/src/components/Sidebar/Sidebar.js
@@ -8,7 +8,6 @@ const useStyles = makeStyles(() => ({
   root: {
     paddingLeft: 21,
     paddingRight: 21,
-    flexGrow: 1,
     maxHeight: '100vh',
     overflowY: 'auto',
   },

--- a/client/src/store/conversations.js
+++ b/client/src/store/conversations.js
@@ -8,6 +8,8 @@ import {
   markMessagesRead,
   markOwnMessagesRead,
   addMessageToUnRead,
+  setSenderTypingTrue,
+  setSenderTypingFalse,
 } from './utils/reducerFunctions';
 
 // ACTIONS
@@ -23,6 +25,8 @@ const ADD_CONVERSATION = 'ADD_CONVERSATION';
 const MESSAGES_READ = 'MESSAGES_READ';
 const SET_UNREAD_MESSAGE = 'SET_UNREAD_MESSAGE';
 const OWN_MESSAGES_READ = 'OWN_MESSAGES_READ';
+const SENDER_TYPING = 'SENDER_TYPING';
+const RESET_SENDER_TYPING = 'RESET_SENDER_TYPING';
 
 // ACTION CREATORS
 
@@ -107,6 +111,22 @@ export const setOwnMessagesRead = conversationId => {
   };
 };
 
+// when conversation sender is typing.
+export const setSenderTyping = conversationId => {
+  return {
+    type: SENDER_TYPING,
+    payload: { conversationId },
+  };
+};
+
+// when sender typing icon should be reset.
+export const resetSenderTyping = conversationId => {
+  return {
+    type: RESET_SENDER_TYPING,
+    payload: { conversationId },
+  };
+};
+
 // REDUCER
 
 const reducer = (state = [], action) => {
@@ -139,6 +159,10 @@ const reducer = (state = [], action) => {
       return markOwnMessagesRead(state, action.payload);
     case SET_UNREAD_MESSAGE:
       return addMessageToUnRead(state, action.payload);
+    case SENDER_TYPING:
+      return setSenderTypingTrue(state, action.payload);
+    case RESET_SENDER_TYPING:
+      return setSenderTypingFalse(state, action.payload);
     default:
       return state;
   }

--- a/client/src/store/utils/reducerFunctions.js
+++ b/client/src/store/utils/reducerFunctions.js
@@ -96,9 +96,9 @@ export const removeOfflineUserFromStore = (state, id) => {
   });
 };
 
-/** When user searches for other users put a fake conversaton in store
- * for each found user with no coversaton yet. This allows ActiveChat
- * to mount correctly and chat to be initalized. */
+/** When user searches for other users put a fake conversation in store
+ * for each found user with no conversation yet. This allows ActiveChat
+ * to mount correctly and chat to be initialized. */
 export const addSearchedUsersToStore = (state, users) => {
   const currentUsers = new Set();
 
@@ -134,7 +134,7 @@ export const addNewConvoToStore = (state, recipientId, message) => {
   });
 };
 
-/** Mark recieved messages of a conversaton as read. */
+/** Mark received messages of a conversation as read. */
 export const markMessagesRead = (state, payload) => {
   const { conversationId } = payload;
   return state.map(convo => {
@@ -163,6 +163,28 @@ export const markOwnMessagesRead = (state, payload) => {
         return msg;
       });
       return convoCopy;
+    } else {
+      return convo;
+    }
+  });
+};
+
+/** Set sender typing true for conversation */
+export const setSenderTypingTrue = (state, payload) => {
+  return state.map(convo => {
+    if (convo.id === payload.conversationId) {
+      return { ...convo, senderTyping: true };
+    } else {
+      return convo;
+    }
+  });
+};
+
+/** Set sender typing true for conversation */
+export const setSenderTypingFalse = (state, payload) => {
+  return state.map(convo => {
+    if (convo.id === payload.conversationId) {
+      return { ...convo, senderTyping: false };
     } else {
       return convo;
     }

--- a/server/bin/www
+++ b/server/bin/www
@@ -76,6 +76,13 @@ io.on('connection', socket => {
       conversationId,
     });
   });
+
+  // when sender is typing
+  socket.on('sender-typing', ({ conversationId, otherUserId }) => {
+    if (onlineUsers.has(otherUserId)) {
+      socket.to(otherUserId).emit('sender-typing', { conversationId });
+    }
+  });
 });
 
 // when a room is deleted from having no more sockets present

--- a/server/db/models/message.js
+++ b/server/db/models/message.js
@@ -6,7 +6,7 @@ const { Op } = Sequelize;
 
 const Message = db.define('message', {
   text: {
-    type: Sequelize.STRING,
+    type: Sequelize.STRING(8000),
     allowNull: false,
   },
   senderId: {


### PR DESCRIPTION
Message read confirmation (recipient avatar) is now only shown below the latest message that was sent.

Added "sender typing" indicator that shows in ActiveChat when the other chat participant is typing a new message. An `OtherUserBubble` component shows with an animated three-dots loader inside as seen in the PDF mockup. I added the `react-loader-spinner` package to be able to show a three-dots loader. MaterialUI does not have this loader.

Updated the code to only broadcast the `message-read` socket event if the document is visible to the user. Using `document.visibilityState` to determine if the document is visible to the user.

I changed the `Home` component to base the sizes of the `Sidebar` and `ActiveChat` on breakpoints using Grid props. This is a change from the sizes being determined by the `flex-grow` CSS setting.  Previously, for example, the width of the sidebar would change depending on the length of the preview message. Now the widths of the Sidebar and ActiveChat are stable and not influenced by any message length.

Changed the code so empty string messages are no longer sent.